### PR TITLE
reverse the issues, gives errors first

### DIFF
--- a/syntax_checkers/rust/clippy.vim
+++ b/syntax_checkers/rust/clippy.vim
@@ -52,7 +52,7 @@ function! SyntaxCheckers_rust_clippy_GetLocList() dict
 
     let issues = filter(loclist, '!empty(v:val["text"])')
 
-    return issues
+    return reverse(issues)
 
 
 endfunction


### PR DESCRIPTION
clippy gives a list of warnings and then errors, which makes sense when
you're building in a terminal, but inside vim/syntastic, it puts the
errors at the bottom of the list.

Maybe there is a better way but I found this immediately more useful.

It is a little odd that searching through the location list forward goes backwards in a file if there are multiple errors there.